### PR TITLE
Speeding up  to_nm method

### DIFF
--- a/lib/mixed_models/daru_methods.rb
+++ b/lib/mixed_models/daru_methods.rb
@@ -12,8 +12,8 @@ module Daru
     def to_nm(dtype: :float64, stype: :dense)
       n, m = self.nrows, self.ncols
       data_array = Array.new 
-      0.upto(n-1) { |i| data_array.concat(self.row[i].to_a) }
-      return NMatrix.new([n,m], data_array, dtype: dtype, stype: stype)
+      self.each { |i| data_array.concat(i.to_a) }
+      return NMatrix.new([m,n], data_array, dtype: dtype, stype: stype).transpose
     end
 
     # Create for all non-numeric vectors 0-1-indicator columns.


### PR DESCRIPTION
I converted a 1000 x 1000 DataFrame to nmatrix.
The original method took around `2.9 seconds` while the new method took around `0.045 seconds`. 
The test can be checked in this [file](https://github.com/agisga/mixed_models/files/205201/test.zip).
